### PR TITLE
Remove envelope case for drums

### DIFF
--- a/litePlay.csd
+++ b/litePlay.csd
@@ -133,11 +133,12 @@ iatt table p7,23
 idec table p7,24
 isus table p7,25
 irel table p7,26
+
 iamp tablei p5, 5
 aenv madsr iatt+1/kr, idec, isus, irel
 imicro = 2^(frac(p4)/12)
 kbend table p7,14
-a1, a2 sfplay p5, int(p4), iamp*aenv*0.0002, imicro*kbend, p6, 0, 0, (p6 < 317 ? 2 : 0) // no env for drum sounds
+a1, a2 sfplay p5, int(p4), iamp*aenv*0.0002, imicro*kbend, p6, 0, 0, 2
 kv table p7, 2
 
 iatt table p7,19


### PR DESCRIPTION
The special case for drums envelope was holding percussion sounds infinitely.